### PR TITLE
fix(clausifier,tests): update assert->have

### DIFF
--- a/src/super/clausifier.lean
+++ b/src/super/clausifier.lean
@@ -194,7 +194,7 @@ assume hab hnenb,
     (assume h : ¬∃x, ¬b x, hab (take x,
       classical.by_cases
         (assume bx : b x, bx)
-        (assume nbx : ¬b x, begin assert hf : false, apply h, existsi x, assumption, contradiction end)))
+        (assume nbx : ¬b x, begin have hf : false, apply h, existsi x, assumption, contradiction end)))
 
 meta def inf_all_l (c : clause) : tactic (list clause) :=
 on_first_left_dn c $ λhnallb,

--- a/test/super_examples.lean
+++ b/test/super_examples.lean
@@ -24,7 +24,7 @@ example (m n : ℕ) : 0 + m = 0 + n → m = n :=
 by super with nat.zero_add
 
 example : ∀x y : ℕ, x + y = y + x :=
-begin intros, induction x, note h : nat.zero = 0 := rfl,
+begin intros, induction x, have h : nat.zero = 0 := rfl,
       super with nat.add_zero nat.zero_add,
       super with nat.add_succ nat.succ_add end
 


### PR DESCRIPTION
If `super/master` is supposed to compile with `lean/master`, this should be merged. If `super/master` should match the release version of Lean, then this will break it.